### PR TITLE
Fix #4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,6 @@
             root = "root";
           };
     in
-      callFlake lockstr src dir;
+      callFlake lockstr { root = { sourceInfo = src; subdir = dir; }; };
   };
 }


### PR DESCRIPTION
This PR updates the arguments passed to `call-flake.nix` changed in dccd5db82eacd81af136ba1d42eba8f18957217c, fixing #4.